### PR TITLE
Fix keyboard controls

### DIFF
--- a/Attract your friends/Assets/Scripts/InputManager.cs
+++ b/Attract your friends/Assets/Scripts/InputManager.cs
@@ -7,18 +7,30 @@ public static class InputManager{
         if (playerNum == 1){
             horizontalInput = Input.GetAxis("Horizontal_Keyboard");
         }
-        return Input.GetAxis("Horizontal_Xbox" + playerNum);
+        return Mathf.Clamp(Input.GetAxis("Horizontal_Xbox" + playerNum) + horizontalInput, -1, 1);
     }
 
     public static bool PullButton(int playerNum){
-        return Input.GetAxis("LTrigger_Xbox" + playerNum) > 0 ? true : false;
+        bool pullInput = false;
+        if (playerNum == 1) {
+            pullInput = Input.GetButton("Pull_Keyboard");
+        }
+        return (Input.GetAxis("LTrigger_Xbox" + playerNum) > 0 ? true : false) || pullInput;
     }
 
     public static bool PushButton(int playerNum){
-        return Input.GetAxis("RTrigger_Xbox" + playerNum) > 0 ? true : false;
+        bool pushInput = false;
+        if (playerNum == 1) {
+            pushInput = Input.GetButton("Push_Keyboard");
+        }
+        return (Input.GetAxis("RTrigger_Xbox" + playerNum) > 0 ? true : false) || pushInput;
     }
 
     public static bool JumpButton(int playerNum){
-        return Input.GetButton("Jump_Xbox" + playerNum);
+        bool jumpInput = false;
+        if (playerNum == 1) {
+            jumpInput = Input.GetButton("Jump_Keyboard");
+        }
+        return Input.GetButton("Jump_Xbox" + playerNum) || jumpInput;
     }
 }

--- a/Attract your friends/Assets/Scripts/InputManager.cs
+++ b/Attract your friends/Assets/Scripts/InputManager.cs
@@ -3,34 +3,18 @@ using System.Collections;
 
 public static class InputManager{
     public static float HorizontalAxis(int playerNum){
-        float horizontalInput = 0;
-        if (playerNum == 1) {
-            horizontalInput = Input.GetAxis("Horizontal");
-        }
-        return Mathf.Clamp(Input.GetAxis("Horizontal_Xbox" + playerNum) + horizontalInput, -1, 1);
+        return Input.GetAxis("Horizontal_Xbox" + playerNum);
     }
 
     public static bool PullButton(int playerNum){
-        bool pullInput = false;
-        if (playerNum == 1) {
-            pullInput = Input.GetKey(KeyCode.K);
-        }
-        return (Input.GetAxis("LTrigger_Xbox" + playerNum) > 0 ? true : false) || pullInput;
+        return Input.GetAxis("LTrigger_Xbox" + playerNum) > 0 ? true : false;
     }
 
     public static bool PushButton(int playerNum){
-        bool pushInput = false;
-        if (playerNum == 1) {
-            pushInput = Input.GetKey(KeyCode.J);
-        }
-        return (Input.GetAxis("RTrigger_Xbox" + playerNum) > 0 ? true : false) || pushInput;
+        return Input.GetAxis("RTrigger_Xbox" + playerNum) > 0 ? true : false;
     }
 
     public static bool JumpButton(int playerNum){
-        bool jumpInput = false;
-        if (playerNum == 1) {
-            jumpInput = Input.GetButton("Jump");
-        }
-        return Input.GetButton("Jump_Xbox" + playerNum) || jumpInput;
+        return Input.GetButton("Jump_Xbox" + playerNum);
     }
 }

--- a/Attract your friends/Assets/Scripts/InputManager.cs
+++ b/Attract your friends/Assets/Scripts/InputManager.cs
@@ -3,6 +3,10 @@ using System.Collections;
 
 public static class InputManager{
     public static float HorizontalAxis(int playerNum){
+        float horizontalInput = 0;
+        if (playerNum == 1){
+            horizontalInput = Input.GetAxis("Horizontal_Keyboard");
+        }
         return Input.GetAxis("Horizontal_Xbox" + playerNum);
     }
 

--- a/Attract your friends/ProjectSettings/InputManager.asset
+++ b/Attract your friends/ProjectSettings/InputManager.asset
@@ -316,7 +316,7 @@ InputManager:
     negativeButton: 
     positiveButton: joystick 2 button 0
     altNegativeButton: 
-    altPositiveButton: 
+    altPositiveButton: joystick 2 button 3
     gravity: 1000
     dead: 0.001
     sensitivity: 1000
@@ -332,7 +332,7 @@ InputManager:
     negativeButton: 
     positiveButton: joystick 3 button 0
     altNegativeButton: 
-    altPositiveButton: 
+    altPositiveButton: joystick 3 button 3
     gravity: 1000
     dead: 0.001
     sensitivity: 1000
@@ -348,7 +348,7 @@ InputManager:
     negativeButton: 
     positiveButton: joystick 4 button 0
     altNegativeButton: 
-    altPositiveButton: 
+    altPositiveButton: joystick 4 button 3
     gravity: 1000
     dead: 0.001
     sensitivity: 1000

--- a/Attract your friends/ProjectSettings/InputManager.asset
+++ b/Attract your friends/ProjectSettings/InputManager.asset
@@ -549,3 +549,67 @@ InputManager:
     type: 2
     axis: 9
     joyNum: 4
+  - serializedVersion: 3
+    m_Name: Horizontal_Keyboard
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: a
+    positiveButton: d
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 1000
+    dead: 0.2
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 0
+  - serializedVersion: 3
+    m_Name: Jump_Keyboard
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: space
+    altNegativeButton: 
+    altPositiveButton: w
+    gravity: 1000
+    dead: 0.2
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 0
+  - serializedVersion: 3
+    m_Name: Push_Keyboard
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: j
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 1000
+    dead: 0.2
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 0
+  - serializedVersion: 3
+    m_Name: Pull_Keyboard
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: k
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 1000
+    dead: 0.2
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 0


### PR DESCRIPTION
This PR fixes a bug that Kate found earlier today.  They were messing around and found that sometimes other players could control player 1.  The issue was in the special casing I wrote for allowing keyboard input for player 1.  It was pulling from the "Horizontal" Input and somehow other controllers were able to influence that value.  I am still not entirely sure how that was happening, so I set up a new Input explicitly stating keyboard controls.  For the sake of defensive coding, I also explicitly stated the rest of the keyboard Inputs while I was at it.  

Also noticed that players 2-3 could not jump with Y.  Went ahead and fixed that as well.